### PR TITLE
Updated unit tests with clock cycle checks

### DIFF
--- a/goboy/emu.go
+++ b/goboy/emu.go
@@ -65,10 +65,10 @@ func (g *GameBoy) Step() {
 					g.LD_de_a(g.mainMemory.readN(pc, 1))
 					/* ld [de], a */
 				case 0x20:
-					g.LD_hli_a(g.mainMemory.readN(pc, 1))
+					g.LDI_hl_a(g.mainMemory.readN(pc, 1))
 					/* LDI [HL], A */
 				case 0x30:
-					g.LD_hld_a(g.mainMemory.readN(pc, 1))
+					g.LDD_hl_a(g.mainMemory.readN(pc, 1))
 					/* LDD [HL], A */
 				}
 			case 0x08:
@@ -81,10 +81,10 @@ func (g *GameBoy) Step() {
 					g.LD_a_de(g.mainMemory.readN(pc, 1))
 					/* ld a, [de] */
 				case 0x20:
-					g.LD_a_hli(g.mainMemory.readN(pc, 1))
+					g.LDI_a_hl(g.mainMemory.readN(pc, 1))
 					/* ldi A, [HL] */
 				case 0x30:
-					g.LD_a_hld(g.mainMemory.readN(pc, 1))
+					g.LDD_a_hl(g.mainMemory.readN(pc, 1))
 					/* ldd A, [HL] */
 				}
 			}

--- a/goboy/opcodes.go
+++ b/goboy/opcodes.go
@@ -136,7 +136,7 @@ func (gb *GameBoy) LD_nn_a(ins []uint8) int {
 }
 
 // Load A <- (HL); HL++
-func (gb *GameBoy) LD_a_hli(ins []uint8) int {
+func (gb *GameBoy) LDI_a_hl(ins []uint8) int {
 	address := gb.get16Reg(HL)
 	value := gb.mainMemory.read(address)
 	gb.set8Reg(A, value)
@@ -146,7 +146,7 @@ func (gb *GameBoy) LD_a_hli(ins []uint8) int {
 }
 
 // Load A <- (HL); HL--
-func (gb *GameBoy) LD_a_hld(ins []uint8) int {
+func (gb *GameBoy) LDD_a_hl(ins []uint8) int {
 	address := gb.get16Reg(HL)
 	value := gb.mainMemory.read(address)
 	gb.set8Reg(A, value)
@@ -156,7 +156,7 @@ func (gb *GameBoy) LD_a_hld(ins []uint8) int {
 }
 
 // Load (HL) <- A; HL++
-func (gb *GameBoy) LD_hli_a(ins []uint8) int {
+func (gb *GameBoy) LDI_hl_a(ins []uint8) int {
 	value := gb.get8Reg(A)
 	address := gb.get16Reg(HL)
 	gb.mainMemory.write(address, value)
@@ -166,7 +166,7 @@ func (gb *GameBoy) LD_hli_a(ins []uint8) int {
 }
 
 // Load (HL) <- A; HL--
-func (gb *GameBoy) LD_hld_a(ins []uint8) int {
+func (gb *GameBoy) LDD_hl_a(ins []uint8) int {
 	value := gb.get8Reg(A)
 	address := gb.get16Reg(HL)
 	gb.mainMemory.write(address, value)
@@ -190,7 +190,7 @@ func (gb *GameBoy) LD_dd_nn(ins []uint8) int {
 func (gb *GameBoy) LD_sp_hl(ins []uint8) int {
 	gb.set16Reg(SP, gb.get16Reg(HL))
 	gb.regs[PC] += uint16(len(ins))
-	return 12
+	return 8
 }
 
 // PUSH qq 1B

--- a/goboy/opcodes_test.go
+++ b/goboy/opcodes_test.go
@@ -16,7 +16,8 @@ func initGameboy() *GameBoy {
 func TestLD_r_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(B, 0xfe)
-	gb.LD_r_r([]uint8{0x50}) // LD D, B
+	cycles := gb.LD_r_r([]uint8{0x50}) // LD D, B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(B), uint8(0xfe))
 	assert.Equal(t, gb.get8Reg(D), uint8(0xfe))
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x0001))
@@ -24,7 +25,8 @@ func TestLD_r_r(t *testing.T) {
 
 func TestLD_r_n(t *testing.T) {
 	gb := initGameboy()
-	gb.LD_r_n([]uint8{0x0e, 0xad}) // LD C, 0xad
+	cycles := gb.LD_r_n([]uint8{0x0e, 0xad}) // LD C, 0xad
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(C), uint8(0xad))
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x0002))
 }
@@ -37,7 +39,8 @@ func TestLD_r_hl(t *testing.T) {
 	memValue := gb.mainMemory.read(0x1234)
 	assert.Equal(t, memValue, uint8(0x42))
 	gb.set16Reg(HL, 0x1234)
-	gb.LD_r_hl([]uint8{0x5e}) // LD E (HL)
+	cycles := gb.LD_r_hl([]uint8{0x5e}) // LD E (HL)
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(E), uint8(0x42))
 }
 
@@ -45,14 +48,16 @@ func TestLD_hl_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(B, 0x42)
 	gb.set16Reg(HL, 0xff85)
-	gb.LD_hl_r([]uint8{0x70}) // LD (HL) B
+	cycles := gb.LD_hl_r([]uint8{0x70}) // LD (HL) B
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x42))
 }
 
 func TestLD_hl_n(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0xff85)
-	gb.LD_hl_n([]uint8{0x36, 0x42}) // LD (HL) 0x42
+	cycles := gb.LD_hl_n([]uint8{0x36, 0x42}) // LD (HL) 0x42
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x42))
 }
 
@@ -65,7 +70,8 @@ func TestLD_a_bc(t *testing.T) {
 	memValue := gb.mainMemory.read(0x1234)
 	assert.Equal(t, memValue, uint8(0x42))
 	gb.set16Reg(BC, 0x1234)
-	gb.LD_a_bc([]uint8{0x0a}) // LD A (BC)
+	cycles := gb.LD_a_bc([]uint8{0x0a}) // LD A (BC)
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x42))
 }
 
@@ -77,7 +83,8 @@ func TestLD_a_de(t *testing.T) {
 	memValue := gb.mainMemory.read(0x1234)
 	assert.Equal(t, memValue, uint8(0x42))
 	gb.set16Reg(DE, 0x1234)
-	gb.LD_a_de([]uint8{0x1a}) // LD A (DE)
+	cycles := gb.LD_a_de([]uint8{0x1a}) // LD A (DE)
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x42))
 }
 
@@ -85,7 +92,8 @@ func TestLD_a_c(t *testing.T) {
 	gb := initGameboy()
 	gb.mainMemory.write(0xff85, 0x42)
 	gb.set8Reg(C, 0x85)
-	gb.LD_a_c([]uint8{0xf2})
+	cycles := gb.LD_a_c([]uint8{0xf2})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x42))
 }
 
@@ -93,21 +101,24 @@ func TestLD_c_a(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0x42)
 	gb.set8Reg(C, 0x85)
-	gb.LD_c_a([]uint8{0xe2})
+	cycles := gb.LD_c_a([]uint8{0xe2})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x42))
 }
 
 func TestLD_a_n(t *testing.T) {
 	gb := initGameboy()
 	gb.mainMemory.write(0xff85, 0x42)
-	gb.LD_a_n([]uint8{0xf0, 0x85})
+	cycles := gb.LD_a_n([]uint8{0xf0, 0x85})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x42))
 }
 
 func TestLD_n_a(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0x42)
-	gb.LD_n_a([]uint8{0xe0, 0x85})
+	cycles := gb.LD_n_a([]uint8{0xe0, 0x85})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x42))
 }
 
@@ -119,7 +130,8 @@ func TestLD_a_nn(t *testing.T) {
 
 	memValue := gb.mainMemory.read(0x1234)
 	assert.Equal(t, memValue, uint8(0x42))
-	gb.LD_a_nn([]uint8{0x3a, 0x34, 0x12}) // LD A (0x1234)
+	cycles := gb.LD_a_nn([]uint8{0x3a, 0x34, 0x12}) // LD A (0x1234)
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x42))
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x3))
 }
@@ -128,7 +140,8 @@ func TestLD_bc_a(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0x42)
 	gb.set16Reg(BC, 0xff85)
-	gb.LD_bc_a([]uint8{0x02}) // LD 0xff85 A
+	cycles := gb.LD_bc_a([]uint8{0x02}) // LD 0xff85 A
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x42))
 }
 
@@ -136,49 +149,55 @@ func TestLD_de_a(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0x42)
 	gb.set16Reg(DE, 0xff85)
-	gb.LD_de_a([]uint8{0x12}) // LD 0xff85 A
+	cycles := gb.LD_de_a([]uint8{0x12}) // LD 0xff85 A
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x42))
 }
 
 func TestLD_nn_a(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0x42)
-	gb.LD_nn_a([]uint8{0x32, 0x85, 0xff}) // LD 0xff85 A
+	cycles := gb.LD_nn_a([]uint8{0x32, 0x85, 0xff}) // LD 0xff85 A
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x42))
 }
 
-func TestLD_a_hli(t *testing.T) {
+func TestLDI_a_hl(t *testing.T) {
 	gb := initGameboy()
 	gb.mainMemory.write(0xff85, 0x42)
 	gb.set16Reg(HL, 0xff85)
-	gb.LD_a_hli([]uint8{0x2a})
+	cycles := gb.LDI_a_hl([]uint8{0x2a})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x42))
 	assert.Equal(t, gb.get16Reg(HL), uint16(0xff86))
 }
 
-func TestLD_a_hld(t *testing.T) {
+func TestLDD_a_hl(t *testing.T) {
 	gb := initGameboy()
 	gb.mainMemory.write(0xff85, 0x42)
 	gb.set16Reg(HL, 0xff85)
-	gb.LD_a_hld([]uint8{0x3a})
+	cycles := gb.LDD_a_hl([]uint8{0x3a})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x42))
 	assert.Equal(t, gb.get16Reg(HL), uint16(0xff84))
 }
 
-func TestLD_hli_a(t *testing.T) {
+func TestLDI_hl_a(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0xff85)
 	gb.set8Reg(A, 0x42)
-	gb.LD_hli_a([]uint8{0x22})
+	cycles := gb.LDI_hl_a([]uint8{0x22})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x42))
 	assert.Equal(t, gb.get16Reg(HL), uint16(0xff86))
 }
 
-func TestLD_hld_a(t *testing.T) {
+func TestLDD_hl_a(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0xff85)
 	gb.set8Reg(A, 0x42)
-	gb.LD_hld_a([]uint8{0x32})
+	cycles := gb.LDD_hl_a([]uint8{0x32})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x42))
 	assert.Equal(t, gb.get16Reg(HL), uint16(0xff84))
 }
@@ -187,14 +206,16 @@ func TestLD_hld_a(t *testing.T) {
 
 func TestLD_dd_nn(t *testing.T) {
 	gb := initGameboy()
-	gb.LD_dd_nn([]uint8{0x21, 0xcd, 0xab}) // LD HL 0xabcd
+	cycles := gb.LD_dd_nn([]uint8{0x21, 0xcd, 0xab}) // LD HL 0xabcd
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(HL), uint16(0xabcd))
 }
 
 func TestLD_sp_hl(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0x1234)
-	gb.LD_sp_hl([]uint8{0xf9}) // LD SP HL (HL = 0x1234)
+	cycles := gb.LD_sp_hl([]uint8{0xf9}) // LD SP HL (HL = 0x1234)
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get16Reg(SP), uint16(0x1234))
 }
 
@@ -202,7 +223,8 @@ func TestPUSH_qq(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0x1234)
 	gb.set16Reg(SP, 0xff85)
-	gb.PUSH_qq([]uint8{0xe5}) // PUSH HL
+	cycles := gb.PUSH_qq([]uint8{0xe5}) // PUSH HL
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.mainMemory.read(0xff84), uint8(0x12))
 	assert.Equal(t, gb.mainMemory.read(0xff83), uint8(0x34))
 }
@@ -212,24 +234,28 @@ func TestPOP_qq(t *testing.T) {
 	gb.set16Reg(SP, 0xff83)
 	gb.mainMemory.write(0xff83, 0x34)
 	gb.mainMemory.write(0xff84, 0x12)
-	gb.POP_qq([]uint8{0xf1}) // POP AF
+	cycles := gb.POP_qq([]uint8{0xf1}) // POP AF
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(AF), uint16(0x1234))
 }
 
 func TestLDHL_sp_e(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(SP, 0x1000)
-	gb.LDHL_sp_e([]uint8{0xf8, 0x42})
+	cycles := gb.LDHL_sp_e([]uint8{0xf8, 0x42})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(HL), uint16(0x1042))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x0))
 
 	gb.set16Reg(SP, 0x0fff)
-	gb.LDHL_sp_e([]uint8{0xf8, 0x42})
+	cycles = gb.LDHL_sp_e([]uint8{0xf8, 0x42})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(HL), uint16(0x1041))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20))
 
 	gb.set16Reg(SP, 0xffff)
-	gb.LDHL_sp_e([]uint8{0xf8, 0x42})
+	cycles = gb.LDHL_sp_e([]uint8{0xf8, 0x42})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(HL), uint16(0x0041))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x30))
 }
@@ -237,7 +263,8 @@ func TestLDHL_sp_e(t *testing.T) {
 func TestLD_nn_sp(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(SP, 0x1234)
-	gb.LD_nn_sp([]uint8{0x08, 0x85, 0xff})
+	cycles := gb.LD_nn_sp([]uint8{0x08, 0x85, 0xff})
+	assert.Equal(t, cycles, 20)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x34))
 	assert.Equal(t, gb.mainMemory.read(0xff86), uint8(0x12))
 }
@@ -247,19 +274,22 @@ func TestLD_nn_sp(t *testing.T) {
 func TestADD_a_r(t *testing.T) {
 	gb := initGameboy()
 	// N_FLAG is always reset
-	gb.ADD_a_r([]uint8{0x80}) // ADD A B
+	cycles := gb.ADD_a_r([]uint8{0x80}) // ADD A B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x0))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 
 	gb.set8Reg(A, 0x0a)
 	gb.set8Reg(B, 0x0c)
-	gb.ADD_a_r([]uint8{0x80}) // ADD A B
+	cycles = gb.ADD_a_r([]uint8{0x80}) // ADD A B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x16))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20)) // H_FLAG is set
 
 	gb.set8Reg(A, 0xf0)
 	gb.set8Reg(B, 0xf0)
-	gb.ADD_a_r([]uint8{0x80}) // ADD A B
+	cycles = gb.ADD_a_r([]uint8{0x80}) // ADD A B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0xe0))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x10)) // C_FLAG is set
 }
@@ -267,17 +297,20 @@ func TestADD_a_r(t *testing.T) {
 func TestADD_a_n(t *testing.T) {
 	// N_FLAG is always reset
 	gb := initGameboy()
-	gb.ADD_a_n([]uint8{0xc6, 0x00}) // ADD A 0x00
+	cycles := gb.ADD_a_n([]uint8{0xc6, 0x00}) // ADD A 0x00
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x0))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 
 	gb.set8Reg(A, 0x0a)
-	gb.ADD_a_n([]uint8{0xc6, 0x0c}) // ADD A 0x0c
+	cycles = gb.ADD_a_n([]uint8{0xc6, 0x0c}) // ADD A 0x0c
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x16))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20)) // H_FLAG is set
 
 	gb.set8Reg(A, 0xf0)
-	gb.ADD_a_n([]uint8{0xc6, 0xf0}) // ADD A 0xf0
+	cycles = gb.ADD_a_n([]uint8{0xc6, 0xf0}) // ADD A 0xf0
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0xe0))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x10)) // C_FLAG is set
 }
@@ -287,20 +320,23 @@ func TestADD_a_hl(t *testing.T) {
 	gb := initGameboy()
 	gbROM := newGBROM()
 	gb.mainMemory.cartridge = gbROM
-	gb.ADD_a_hl([]uint8{0x86}) // ADD A HL
+	cycles := gb.ADD_a_hl([]uint8{0x86}) // ADD A HL
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x0))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 	gb.set8Reg(A, 0x0a)
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x0c)
-	gb.ADD_a_hl([]uint8{0x86}) // ADD A HL
+	cycles = gb.ADD_a_hl([]uint8{0x86}) // ADD A HL
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x16))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20)) // H_FLAG is set
 
 	gb.set8Reg(A, 0xf0)
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0xf0)
-	gb.ADD_a_hl([]uint8{0x86}) // ADD A HL
+	cycles = gb.ADD_a_hl([]uint8{0x86}) // ADD A HL
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0xe0))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x10)) // C_FLAG is set
 }
@@ -308,21 +344,24 @@ func TestADD_a_hl(t *testing.T) {
 func TestADC_a_r(t *testing.T) {
 	gb := initGameboy()
 	// N_FLAG is always reset
-	gb.ADC_a_r([]uint8{0x88}) // ADC A B
+	cycles := gb.ADC_a_r([]uint8{0x88}) // ADC A B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x0))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 
 	gb.set8Reg(A, 0x0a)
 	gb.set8Reg(B, 0x0c)
 	gb.set8Reg(F, 0x10)
-	gb.ADC_a_r([]uint8{0x88}) // ADC A B
+	cycles = gb.ADC_a_r([]uint8{0x88}) // ADC A B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x17))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20)) // H_FLAG is set
 
 	gb.set8Reg(A, 0xf0)
 	gb.set8Reg(B, 0xf0)
 	gb.set8Reg(F, 0x10)
-	gb.ADC_a_r([]uint8{0x88}) // ADC A B
+	cycles = gb.ADC_a_r([]uint8{0x88}) // ADC A B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0xe1))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x10)) // C_FLAG is set
 }
@@ -330,19 +369,22 @@ func TestADC_a_r(t *testing.T) {
 func TestADC_a_n(t *testing.T) {
 	// N_FLAG is always reset
 	gb := initGameboy()
-	gb.ADC_a_n([]uint8{0xce, 0x00}) // ADC A 0x00
+	cycles := gb.ADC_a_n([]uint8{0xce, 0x00}) // ADC A 0x00
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 
 	gb.set8Reg(A, 0x0a)
 	gb.set8Reg(F, 0x10)
-	gb.ADC_a_n([]uint8{0xce, 0x0c}) // ADC A 0x0c
+	cycles = gb.ADC_a_n([]uint8{0xce, 0x0c}) // ADC A 0x0c
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x17))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20)) // H_FLAG is set
 
 	gb.set8Reg(A, 0xf0)
 	gb.set8Reg(F, 0x10)
-	gb.ADC_a_n([]uint8{0xce, 0xf0}) // ADC A 0xf0
+	cycles = gb.ADC_a_n([]uint8{0xce, 0xf0}) // ADC A 0xf0
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0xe1))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x10)) // C_FLAG is set
 }
@@ -352,7 +394,8 @@ func TestADC_a_hl(t *testing.T) {
 	gb := initGameboy()
 	gbROM := newGBROM()
 	gb.mainMemory.cartridge = gbROM
-	gb.ADC_a_hl([]uint8{0x8e}) // ADC A HL
+	cycles := gb.ADC_a_hl([]uint8{0x8e}) // ADC A HL
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x0))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 
@@ -360,7 +403,8 @@ func TestADC_a_hl(t *testing.T) {
 	gb.set8Reg(F, 0x10)
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x0c)
-	gb.ADC_a_hl([]uint8{0x8e}) // ADC A HL
+	cycles = gb.ADC_a_hl([]uint8{0x8e}) // ADC A HL
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x17))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20)) // H_FLAG is set
 
@@ -368,54 +412,63 @@ func TestADC_a_hl(t *testing.T) {
 	gb.set8Reg(F, 0x10)
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0xf0)
-	gb.ADC_a_hl([]uint8{0x8e}) // ADC A HL
+	cycles = gb.ADC_a_hl([]uint8{0x8e}) // ADC A HL
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0xe1))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x10)) // C_FLAG is set
 }
 
 func TestSUB_a_r(t *testing.T) {
 	gb := initGameboy()
-	gb.SUB_a_r([]uint8{0x90})
+	cycles := gb.SUB_a_r([]uint8{0x90})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xc0)) // Z_FLAG and N_FLAG is set
 
 	gb.set8Reg(A, 0x02)
 	gb.set8Reg(B, 0x01)
-	gb.SUB_a_r([]uint8{0x90})
+	cycles = gb.SUB_a_r([]uint8{0x90})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x01))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x40)) // N_FLAG is set
 
 	gb.set8Reg(A, 0x87)
 	gb.set8Reg(B, 0x0f)
-	gb.SUB_a_r([]uint8{0x90})
+	cycles = gb.SUB_a_r([]uint8{0x90})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x78))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x60)) // N_FLAG and H_FLAG is set
 
 	gb.set8Reg(A, 0x0f)
 	gb.set8Reg(B, 0xf0)
-	gb.SUB_a_r([]uint8{0x90})
+	cycles = gb.SUB_a_r([]uint8{0x90})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x1f))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x50)) // N_FLAG and C_FLAG is set
 }
 
 func TestSUB_a_n(t *testing.T) {
 	gb := initGameboy()
-	gb.SUB_a_n([]uint8{0xd6, 0x00})
+	cycles := gb.SUB_a_n([]uint8{0xd6, 0x00})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xc0)) // Z_FLAG and N_FLAG is set
 
 	gb.set8Reg(A, 0x02)
-	gb.SUB_a_n([]uint8{0xd6, 0x01})
+	cycles = gb.SUB_a_n([]uint8{0xd6, 0x01})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x01))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x40)) // N_FLAG is set
 
 	gb.set8Reg(A, 0x87)
-	gb.SUB_a_n([]uint8{0xd6, 0x0f})
+	cycles = gb.SUB_a_n([]uint8{0xd6, 0x0f})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x78))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x60)) // N_FLAG and H_FLAG is set
 
 	gb.set8Reg(A, 0x0f)
-	gb.SUB_a_n([]uint8{0xd6, 0xf0})
+	cycles = gb.SUB_a_n([]uint8{0xd6, 0xf0})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x1f))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x50)) // N_FLAG and C_FLAG is set
 }
@@ -424,81 +477,93 @@ func TestSUB_a_hl(t *testing.T) {
 	gb := initGameboy()
 	gbROM := newGBROM()
 	gb.mainMemory.cartridge = gbROM
-	gb.SUB_a_hl([]uint8{0x96})
+	cycles := gb.SUB_a_hl([]uint8{0x96})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xc0)) // Z_FLAG and N_FLAG is set
 
 	gb.set8Reg(A, 0x02)
 	gb.mainMemory.write(0xff85, 0x01)
 	gb.set16Reg(HL, 0xff85)
-	gb.SUB_a_hl([]uint8{0x96})
+	cycles = gb.SUB_a_hl([]uint8{0x96})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x01))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x40)) // N_FLAG is set
 
 	gb.set8Reg(A, 0x87)
 	gb.mainMemory.write(0xff85, 0x0f)
 	gb.set16Reg(HL, 0xff85)
-	gb.SUB_a_hl([]uint8{0x96})
+	cycles = gb.SUB_a_hl([]uint8{0x96})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x78))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x60)) // N_FLAG and H_FLAG is set
 
 	gb.set8Reg(A, 0x0f)
 	gb.mainMemory.write(0xff85, 0xf0)
 	gb.set16Reg(HL, 0xff85)
-	gb.SUB_a_hl([]uint8{0x96})
+	cycles = gb.SUB_a_hl([]uint8{0x96})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x1f))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x50)) // N_FLAG and C_FLAG is set
 }
 
 func TestSBC_a_r(t *testing.T) {
 	gb := initGameboy()
-	gb.SBC_a_r([]uint8{0x98})
+	cycles := gb.SBC_a_r([]uint8{0x98})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xc0)) // Z_FLAG and N_FLAG is set
 
 	gb.set8Reg(A, 0x03)
 	gb.set8Reg(B, 0x01)
 	gb.set8Reg(F, 0x10)
-	gb.SBC_a_r([]uint8{0x98})
+	cycles = gb.SBC_a_r([]uint8{0x98})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x01))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x40)) // N_FLAG is set
 
 	gb.set8Reg(A, 0x87)
 	gb.set8Reg(B, 0x0e)
 	gb.set8Reg(F, 0x10)
-	gb.SBC_a_r([]uint8{0x98})
+	cycles = gb.SBC_a_r([]uint8{0x98})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x78))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x60)) // N_FLAG and H_FLAG is set
 
 	gb.set8Reg(A, 0x0f)
 	gb.set8Reg(B, 0xef)
 	gb.set8Reg(F, 0x10)
-	gb.SBC_a_r([]uint8{0x98})
+	cycles = gb.SBC_a_r([]uint8{0x98})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x1f))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x50)) // N_FLAG and C_FLAG is set
 }
 
 func TestSBC_a_n(t *testing.T) {
 	gb := initGameboy()
-	gb.SBC_a_n([]uint8{0xde, 0x00})
+	cycles := gb.SBC_a_n([]uint8{0xde, 0x00})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xc0)) // Z_FLAG and N_FLAG is set
 
 	gb.set8Reg(A, 0x03)
 	gb.set8Reg(F, 0x10)
-	gb.SBC_a_n([]uint8{0xde, 0x01})
+	cycles = gb.SBC_a_n([]uint8{0xde, 0x01})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x01))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x40)) // N_FLAG is set
 
 	gb.set8Reg(A, 0x87)
 	gb.set8Reg(F, 0x10)
-	gb.SBC_a_n([]uint8{0xde, 0x0e})
+	cycles = gb.SBC_a_n([]uint8{0xde, 0x0e})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x78))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x60)) // N_FLAG and H_FLAG is set
 
 	gb.set8Reg(A, 0x0f)
 	gb.set8Reg(F, 0x10)
-	gb.SBC_a_n([]uint8{0xde, 0xef})
+	cycles = gb.SBC_a_n([]uint8{0xde, 0xef})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x1f))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x50)) // N_FLAG and C_FLAG is set
 }
@@ -507,7 +572,8 @@ func TestSBC_a_hl(t *testing.T) {
 	gb := initGameboy()
 	gbROM := newGBROM()
 	gb.mainMemory.cartridge = gbROM
-	gb.SBC_a_hl([]uint8{0x9e})
+	cycles := gb.SBC_a_hl([]uint8{0x9e})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xc0)) // Z_FLAG and N_FLAG is set
 
@@ -515,7 +581,8 @@ func TestSBC_a_hl(t *testing.T) {
 	gb.set8Reg(F, 0x10)
 	gb.mainMemory.write(0xff85, 0x01)
 	gb.set16Reg(HL, 0xff85)
-	gb.SBC_a_hl([]uint8{0x9e})
+	cycles = gb.SBC_a_hl([]uint8{0x9e})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x01))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x40)) // N_FLAG is set
 
@@ -523,7 +590,8 @@ func TestSBC_a_hl(t *testing.T) {
 	gb.set8Reg(F, 0x10)
 	gb.mainMemory.write(0xff85, 0x0e)
 	gb.set16Reg(HL, 0xff85)
-	gb.SBC_a_hl([]uint8{0x9e})
+	cycles = gb.SBC_a_hl([]uint8{0x9e})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x78))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x60)) // N_FLAG and H_FLAG is set
 
@@ -531,7 +599,8 @@ func TestSBC_a_hl(t *testing.T) {
 	gb.set8Reg(F, 0x10)
 	gb.mainMemory.write(0xff85, 0xef)
 	gb.set16Reg(HL, 0xff85)
-	gb.SBC_a_hl([]uint8{0x9e})
+	cycles = gb.SBC_a_hl([]uint8{0x9e})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x1f))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x50)) // N_FLAG and C_FLAG is set
 }
@@ -540,13 +609,15 @@ func TestAND_a_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0xcc)
 	gb.set8Reg(B, 0xaf)
-	gb.AND_a_r([]uint8{0xa0}) // AND A B
+	cycles := gb.AND_a_r([]uint8{0xa0}) // AND A B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x8c))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20)) // H_FLAG is set
 
 	gb.set8Reg(A, 0x12)
 	gb.set8Reg(B, 0x00)
-	gb.AND_a_r([]uint8{0xa0}) // AND A B
+	cycles = gb.AND_a_r([]uint8{0xa0}) // AND A B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xa0)) // H_FLAG and Z_FLAG are set
 }
@@ -554,13 +625,15 @@ func TestAND_a_r(t *testing.T) {
 func TestAND_a_n(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0xcc)
-	gb.AND_a_n([]uint8{0xe6, 0xaf}) // AND A 0xaf
+	cycles := gb.AND_a_n([]uint8{0xe6, 0xaf}) // AND A 0xaf
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x8c))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20)) // H_FLAG is set
 
 	gb.set8Reg(A, 0x12)
 	gb.set8Reg(B, 0x00)
-	gb.AND_a_n([]uint8{0xe6, 0x00}) // AND A 0x00
+	cycles = gb.AND_a_n([]uint8{0xe6, 0x00}) // AND A 0x00
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xa0)) // H_FLAG and Z_FLAG are set
 }
@@ -570,14 +643,16 @@ func TestAND_a_hl(t *testing.T) {
 	gb.set8Reg(A, 0xcc)
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0xaf)
-	gb.AND_a_hl([]uint8{0xa6})
+	cycles := gb.AND_a_hl([]uint8{0xa6})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x8c))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20)) // H_FLAG is set
 
 	gb.set8Reg(A, 0x12)
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x00)
-	gb.AND_a_hl([]uint8{0xa6})
+	cycles = gb.AND_a_hl([]uint8{0xa6})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xa0)) // H_FLAG and Z_FLAG are set
 }
@@ -586,12 +661,14 @@ func TestOR_a_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0xaa)
 	gb.set8Reg(B, 0x55)
-	gb.OR_a_r([]uint8{0xb0}) // OR b
+	cycles := gb.OR_a_r([]uint8{0xb0}) // OR b
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0xff))
 
 	gb.set8Reg(A, 0x00)
 	gb.set8Reg(B, 0x00)
-	gb.OR_a_r([]uint8{0xb0}) // OR b
+	cycles = gb.OR_a_r([]uint8{0xb0}) // OR b
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 }
@@ -599,11 +676,13 @@ func TestOR_a_r(t *testing.T) {
 func TestOR_a_n(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0xaa)
-	gb.OR_a_n([]uint8{0xf6, 0x55}) // OR 0x55
+	cycles := gb.OR_a_n([]uint8{0xf6, 0x55}) // OR 0x55
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0xff))
 
 	gb.set8Reg(A, 0x00)
-	gb.OR_a_n([]uint8{0xf6, 0x00}) // OR 0x00
+	cycles = gb.OR_a_n([]uint8{0xf6, 0x00}) // OR 0x00
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 }
@@ -613,13 +692,15 @@ func TestOR_a_hl(t *testing.T) {
 	gb.set8Reg(A, 0xaa)
 	gb.mainMemory.write(0xff85, 0x55)
 	gb.set16Reg(HL, 0xff85)
-	gb.OR_a_hl([]uint8{0xb6}) // OR (HL)
+	cycles := gb.OR_a_hl([]uint8{0xb6}) // OR (HL)
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0xff))
 
 	gb.set8Reg(A, 0x00)
 	gb.mainMemory.write(0xff85, 0x00)
 	gb.set16Reg(HL, 0xff85)
-	gb.OR_a_hl([]uint8{0xb6}) // OR (HL)
+	cycles = gb.OR_a_hl([]uint8{0xb6}) // OR (HL)
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 }
@@ -628,12 +709,14 @@ func TestXOR_a_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0xaa)
 	gb.set8Reg(B, 0xff)
-	gb.XOR_a_r([]uint8{0xa8}) // XOR B
+	cycles := gb.XOR_a_r([]uint8{0xa8}) // XOR B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x55))
 
 	gb.set8Reg(A, 0xaa)
 	gb.set8Reg(B, 0xaa)
-	gb.XOR_a_r([]uint8{0xa8}) // XOR B
+	cycles = gb.XOR_a_r([]uint8{0xa8}) // XOR B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 }
@@ -641,11 +724,13 @@ func TestXOR_a_r(t *testing.T) {
 func TestXOR_a_n(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0xaa)
-	gb.XOR_a_n([]uint8{0xee, 0xff}) // XOR 0xff
+	cycles := gb.XOR_a_n([]uint8{0xee, 0xff}) // XOR 0xff
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x55))
 
 	gb.set8Reg(A, 0xaa)
-	gb.XOR_a_n([]uint8{0xee, 0xaa}) // XOR 0xaa
+	cycles = gb.XOR_a_n([]uint8{0xee, 0xaa}) // XOR 0xaa
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 }
@@ -655,13 +740,15 @@ func TestXOR_a_hl(t *testing.T) {
 	gb.set8Reg(A, 0xaa)
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0xff)
-	gb.XOR_a_hl([]uint8{0xae}) // XOR (HL)
+	cycles := gb.XOR_a_hl([]uint8{0xae}) // XOR (HL)
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x55))
 
 	gb.set8Reg(A, 0xaa)
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0xaa)
-	gb.XOR_a_hl([]uint8{0xae}) // XOR (HL)
+	cycles = gb.XOR_a_hl([]uint8{0xae}) // XOR (HL)
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x80)) // Z_FLAG is set
 }
@@ -670,17 +757,20 @@ func TestCP_a_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0x05)
 	gb.set8Reg(B, 0x02)
-	gb.CP_a_r([]uint8{0xb8})                    // CP B
+	cycles := gb.CP_a_r([]uint8{0xb8}) // CP B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(F), uint8(0x60)) // H_FLAG and N_FLAG is set
 
 	gb.set8Reg(A, 0x02)
 	gb.set8Reg(B, 0x05)
-	gb.CP_a_r([]uint8{0xb8})                    // CP B
+	cycles = gb.CP_a_r([]uint8{0xb8}) // CP B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(F), uint8(0x50)) // C_FLAG and N_FLAG is set
 
 	gb.set8Reg(A, 0x03)
 	gb.set8Reg(B, 0x03)
-	gb.CP_a_r([]uint8{0xb8})                    // CP B
+	cycles = gb.CP_a_r([]uint8{0xb8}) // CP B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(F), uint8(0xc0)) // N_FLAG and Z_FLAG is set
 }
 
@@ -688,17 +778,20 @@ func TestCP_a_n(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0x05)
 	gb.set8Reg(B, 0x02)
-	gb.CP_a_n([]uint8{0xfe, 0x02})              // CP 0x02
+	cycles := gb.CP_a_n([]uint8{0xfe, 0x02}) // CP 0x02
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(F), uint8(0x60)) // H_FLAG and N_FLAG is set
 
 	gb.set8Reg(A, 0x02)
 	gb.set8Reg(B, 0x05)
-	gb.CP_a_n([]uint8{0xfe, 0x05})              // CP 0x05
+	cycles = gb.CP_a_n([]uint8{0xfe, 0x05}) // CP 0x05
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(F), uint8(0x50)) // C_FLAG and N_FLAG is set
 
 	gb.set8Reg(A, 0x03)
 	gb.set8Reg(B, 0x03)
-	gb.CP_a_n([]uint8{0xfe, 0x03})              // CP 0x03
+	cycles = gb.CP_a_n([]uint8{0xfe, 0x03}) // CP 0x03
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(F), uint8(0xc0)) // N_FLAG and Z_FLAG is set
 }
 
@@ -707,36 +800,42 @@ func TestCP_a_hl(t *testing.T) {
 	gb.set8Reg(A, 0x05)
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x02)
-	gb.CP_a_hl([]uint8{0xbe})                   // CP (HL)
+	cycles := gb.CP_a_hl([]uint8{0xbe}) // CP (HL)
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(F), uint8(0x60)) // H_FLAG and N_FLAG is set
 
 	gb.set8Reg(A, 0x02)
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x05)
-	gb.CP_a_hl([]uint8{0xbe})                   // CP (HL)
+	cycles = gb.CP_a_hl([]uint8{0xbe}) // CP (HL)
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(F), uint8(0x50)) // C_FLAG and N_FLAG is set
 
 	gb.set8Reg(A, 0x03)
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x03)
-	gb.CP_a_hl([]uint8{0xbe})                   // CP (HL)
+	cycles = gb.CP_a_hl([]uint8{0xbe}) // CP (HL)
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(F), uint8(0xc0)) // Z_FLAG and N_FLAG is set
 }
 
 func TestINC_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(B, 0x41)
-	gb.INC_r([]uint8{0x04})
+	cycles := gb.INC_r([]uint8{0x04})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(B), uint8(0x42)) // INC B
 	assert.Equal(t, gb.get8Reg(F), uint8(0x00))
 
 	gb.set8Reg(B, 0xff)
-	gb.INC_r([]uint8{0x04})
+	cycles = gb.INC_r([]uint8{0x04})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(B), uint8(0x00)) // INC B
 	assert.Equal(t, gb.get8Reg(F), uint8(0xa0)) // H_FLAG and Z_FLAG is set
 
 	gb.set8Reg(B, 0x0f)
-	gb.INC_r([]uint8{0x04})
+	cycles = gb.INC_r([]uint8{0x04})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(B), uint8(0x10)) // INC B
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20)) // H_FLAG is set
 }
@@ -745,19 +844,22 @@ func TestINC_hl(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x41)
-	gb.INC_hl([]uint8{0xbe}) // INC (HL)
+	cycles := gb.INC_hl([]uint8{0xbe}) // INC (HL)
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x42))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x00))
 
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0xff)
-	gb.INC_hl([]uint8{0xbe}) // INC (HL)
+	cycles = gb.INC_hl([]uint8{0xbe}) // INC (HL)
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xa0)) // H_FLAG and Z_FLAG is set
 
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x0f)
-	gb.INC_hl([]uint8{0xbe}) // INC (HL)
+	cycles = gb.INC_hl([]uint8{0xbe}) // INC (HL)
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x10))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20)) // H_FLAG is set
 }
@@ -765,17 +867,20 @@ func TestINC_hl(t *testing.T) {
 func TestDEC_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(B, 0x41)
-	gb.DEC_r([]uint8{0x05}) // DEC B
+	cycles := gb.DEC_r([]uint8{0x05}) // DEC B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(B), uint8(0x40))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x40)) // N_FLAG is set
 
 	gb.set8Reg(B, 0x01)
-	gb.DEC_r([]uint8{0x05}) // DEC B
+	cycles = gb.DEC_r([]uint8{0x05}) // DEC B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(B), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xc0)) // N_FLAG and Z_FLAG is set
 
 	gb.set8Reg(B, 0x00)
-	gb.DEC_r([]uint8{0x05}) // DEC B
+	cycles = gb.DEC_r([]uint8{0x05}) // DEC B
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(B), uint8(0xff))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x60)) // N_FLAG and H_FLAG is set
 }
@@ -784,19 +889,22 @@ func TestDEC_hl(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x41)
-	gb.DEC_hl([]uint8{0xbe}) // DEC (HL)
+	cycles := gb.DEC_hl([]uint8{0xbe}) // DEC (HL)
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x40))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x40)) // N_FLAG is set
 
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x01)
-	gb.DEC_hl([]uint8{0xbe}) // DEC (HL)
+	cycles = gb.DEC_hl([]uint8{0xbe}) // DEC (HL)
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x00))
 	assert.Equal(t, gb.get8Reg(F), uint8(0xc0)) // N_FLAG and Z_FLAG is set
 
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x00)
-	gb.DEC_hl([]uint8{0xbe}) // DEC (HL)
+	cycles = gb.DEC_hl([]uint8{0xbe}) // DEC (HL)
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0xff))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x60)) // M_FLAG and H_FLAG is set
 }
@@ -805,13 +913,15 @@ func TestADD_hl_ss(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0x0fff)
 	gb.set16Reg(BC, 0x0001)
-	gb.ADD_hl_ss([]uint8{0x09})
+	cycles := gb.ADD_hl_ss([]uint8{0x09})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get16Reg(HL), uint16(0x1000))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20))
 
 	gb.set16Reg(HL, 0xf000)
 	gb.set16Reg(BC, 0x1001)
-	gb.ADD_hl_ss([]uint8{0x09})
+	cycles = gb.ADD_hl_ss([]uint8{0x09})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get16Reg(HL), uint16(0x0001))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x10))
 }
@@ -819,17 +929,20 @@ func TestADD_hl_ss(t *testing.T) {
 func TestADD_sp_e(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(SP, 0x0fff)
-	gb.ADD_sp_e([]uint8{0xe8, 0x01})
+	cycles := gb.ADD_sp_e([]uint8{0xe8, 0x01})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.get16Reg(SP), uint16(0x1000))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x20))
 
 	gb.set16Reg(SP, 0xffff)
-	gb.ADD_sp_e([]uint8{0xe8, 0x01})
+	cycles = gb.ADD_sp_e([]uint8{0xe8, 0x01})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.get16Reg(SP), uint16(0x0000))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x30))
 
 	gb.set16Reg(SP, 0xffff)
-	gb.ADD_sp_e([]uint8{0xe8, 0xff})
+	cycles = gb.ADD_sp_e([]uint8{0xe8, 0xff})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.get16Reg(SP), uint16(0xfffe))
 	assert.Equal(t, gb.get8Reg(F), uint8(0x30))
 
@@ -837,14 +950,16 @@ func TestADD_sp_e(t *testing.T) {
 
 func TestINC_ss(t *testing.T) {
 	gb := initGameboy()
-	gb.INC_ss([]uint8{0x13})
+	cycles := gb.INC_ss([]uint8{0x13})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get16Reg(DE), uint16(0x0001))
 }
 
 func TestDEC_ss(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(DE, 0x01)
-	gb.DEC_ss([]uint8{0x1b})
+	cycles := gb.DEC_ss([]uint8{0x1b})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get16Reg(DE), uint16(0x0000))
 }
 
@@ -852,7 +967,8 @@ func TestRLCA(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0x85)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.RLCA([]uint8{0x00}) // RLCA
+	cycles := gb.RLCA([]uint8{0x00}) // RLCA
+	assert.Equal(t, cycles, 4)
 	// result should be 0x0b (which contradicts the GB programming manual)
 	// discussion: https://hax.iimarckus.org/topic/1617/
 	assert.Equal(t, uint8(0x0b), gb.get8Reg(A))
@@ -863,7 +979,8 @@ func TestRLA(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0x95)
 	gb.modifyFlag(C_FLAG, SET)
-	gb.RLA([]uint8{0x00}) // RLA
+	cycles := gb.RLA([]uint8{0x00}) // RLA
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, uint8(0x2b), gb.get8Reg(A))
 	assert.Equal(t, uint8(0x10), gb.get8Reg(F)) // C FLAG set, Z,H,N FLAG cleared
 }
@@ -872,7 +989,8 @@ func TestRRCA(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0x3b)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.RRCA([]uint8{0x00}) // RRCA
+	cycles := gb.RRCA([]uint8{0x00}) // RRCA
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, uint8(0x9d), gb.get8Reg(A))
 	assert.Equal(t, uint8(0x10), gb.get8Reg(F)) // C FLAG set, Z,H,N FLAG cleared
 }
@@ -881,7 +999,8 @@ func TestRRA(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0x81)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.RRA([]uint8{0x00}) // RRA
+	cycles := gb.RRA([]uint8{0x00}) // RRA
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, uint8(0x40), gb.get8Reg(A))
 	assert.Equal(t, uint8(0x10), gb.get8Reg(F)) // C FLAG set, Z,H,N FLAG cleared
 }
@@ -890,7 +1009,8 @@ func TestRLC_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(B, 0x85)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.RLC_r([]uint8{0x05}) // RLC_r
+	cycles := gb.RLC_r([]uint8{0x05}) // RLC_r
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, uint8(0x0b), gb.get8Reg(B))
 	assert.Equal(t, uint8(0x10), gb.get8Reg(F)) // C FLAG set, Z,H,N FLAG cleared
 }
@@ -900,7 +1020,8 @@ func TestRLC_hl(t *testing.T) {
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x00)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.RLC_hl([]uint8{0xbe}) // RLC_hl
+	cycles := gb.RLC_hl([]uint8{0xbe}) // RLC_hl
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, uint8(0x00), gb.mainMemory.read(0xff85))
 	assert.Equal(t, uint8(0x80), gb.get8Reg(F)) // Z FLAG set, C,H,N FLAG cleared
 }
@@ -908,11 +1029,13 @@ func TestRLC_hl(t *testing.T) {
 func TestBIT_b_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(B, 0x80)
-	gb.BIT_b_r([]uint8{0xcb, 0x78})
+	cycles := gb.BIT_b_r([]uint8{0xcb, 0x78})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.getFlag(Z_FLAG), uint8(0x00))
 
 	gb.set8Reg(C, 0xef)
-	gb.BIT_b_r([]uint8{0xcb, 0x61})
+	cycles = gb.BIT_b_r([]uint8{0xcb, 0x61})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.getFlag(Z_FLAG), uint8(0x01))
 }
 
@@ -920,30 +1043,35 @@ func TestBIT_b_hl(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0xfe)
-	gb.BIT_b_hl([]uint8{0xcb, 0x46})
+	cycles := gb.BIT_b_hl([]uint8{0xcb, 0x46})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.getFlag(Z_FLAG), uint8(0x01))
 
-	gb.BIT_b_hl([]uint8{0xcb, 0x4e})
+	cycles = gb.BIT_b_hl([]uint8{0xcb, 0x4e})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.getFlag(Z_FLAG), uint8(0x00))
 }
 
 func TestSET_b_r(t *testing.T) {
 	gb := initGameboy()
-	gb.SET_b_r([]uint8{0xcb, 0xc0})
+	cycles := gb.SET_b_r([]uint8{0xcb, 0xc0})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(B), uint8(0x01))
 }
 
 func TestSET_b_hl(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0xff85)
-	gb.SET_b_hl([]uint8{0xcb, 0xc6})
+	cycles := gb.SET_b_hl([]uint8{0xcb, 0xc6})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0x01))
 }
 
 func TestRES_b_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(B, 0xff)
-	gb.RES_b_r([]uint8{0xcb, 0x80})
+	cycles := gb.RES_b_r([]uint8{0xcb, 0x80})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get8Reg(B), uint8(0xfe))
 }
 
@@ -951,72 +1079,85 @@ func TestRES_b_hl(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0xff)
-	gb.RES_b_hl([]uint8{0xcb, 0x86})
+	cycles := gb.RES_b_hl([]uint8{0xcb, 0x86})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.mainMemory.read(0xff85), uint8(0xfe))
 }
 
 func TestJP_nn(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(PC, 0x1234)
-	gb.JP_nn([]uint8{0xc3, 0x78, 0x56})
+	cycles := gb.JP_nn([]uint8{0xc3, 0x78, 0x56})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x5678))
 }
 
 func TestJP_cc_nn(t *testing.T) {
 	gb := initGameboy()
-	gb.JP_cc_nn([]uint8{0xc2, 0x34, 0x12})
+	cycles := gb.JP_cc_nn([]uint8{0xc2, 0x34, 0x12})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x1234))
 
 	gb.set16Reg(PC, 0x0000)
 	gb.modifyFlag(Z_FLAG, SET)
-	gb.JP_cc_nn([]uint8{0xc2, 0x34, 0x12})
+	cycles = gb.JP_cc_nn([]uint8{0xc2, 0x34, 0x12})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x0003))
 
 	gb.set16Reg(PC, 0x0000)
 	gb.modifyFlag(C_FLAG, SET)
-	gb.JP_cc_nn([]uint8{0xda, 0x34, 0x12})
+	cycles = gb.JP_cc_nn([]uint8{0xda, 0x34, 0x12})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x1234))
 
 	gb.set16Reg(PC, 0x0000)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.JP_cc_nn([]uint8{0xda, 0x34, 0x12})
+	cycles = gb.JP_cc_nn([]uint8{0xda, 0x34, 0x12})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x0003))
 }
 
 func TestJR_e(t *testing.T) {
 	gb := initGameboy()
-	gb.JR_e([]uint8{0x18, 0x0a})
+	cycles := gb.JR_e([]uint8{0x18, 0x0a})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x000c))
 
-	gb.JR_e([]uint8{0x18, 0xf9})
+	cycles = gb.JR_e([]uint8{0x18, 0xf9})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x0007))
 }
 
 func TestJR_cc_e(t *testing.T) {
 	gb := initGameboy()
-	gb.JR_cc_e([]uint8{0x20, 0x0a})
+	cycles := gb.JR_cc_e([]uint8{0x20, 0x0a})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x000c))
 
 	gb.set16Reg(PC, 0x0000)
 	gb.modifyFlag(Z_FLAG, SET)
-	gb.JR_cc_e([]uint8{0x20, 0xf9})
+	cycles = gb.JR_cc_e([]uint8{0x20, 0xf9})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x0002))
 
 	gb.set16Reg(PC, 0x000c)
 	gb.modifyFlag(C_FLAG, SET)
-	gb.JR_cc_e([]uint8{0x38, 0xf9})
+	cycles = gb.JR_cc_e([]uint8{0x38, 0xf9})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x0007))
 
 	gb.set16Reg(PC, 0x000c)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.JR_cc_e([]uint8{0x38, 0x34})
+	cycles = gb.JR_cc_e([]uint8{0x38, 0x34})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x000e))
 }
 
 func TestJP_hl(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(HL, 0x1234)
-	gb.JP_hl([]uint8{0xe9})
+	cycles := gb.JP_hl([]uint8{0xe9})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x1234))
 }
 
@@ -1025,7 +1166,8 @@ func TestCALL_nn(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(PC, 0x1122)
 	gb.set16Reg(SP, 0xffff)
-	gb.CALL_nn([]uint8{0xcd, 0x34, 0x12})
+	cycles := gb.CALL_nn([]uint8{0xcd, 0x34, 0x12})
+	assert.Equal(t, cycles, 24)
 	assert.Equal(t, gb.get16Reg(SP), uint16(0xfffd))
 	assert.Equal(t, gb.mainMemory.read(0xfffe), uint8(0x11))
 	assert.Equal(t, gb.mainMemory.read(0xfffd), uint8(0x25))
@@ -1037,7 +1179,8 @@ func TestCALL_cc_nn(t *testing.T) {
 	// Z_FLAG cases
 	gb.set16Reg(PC, 0x1122)
 	gb.set16Reg(SP, 0xffff)
-	gb.CALL_cc_nn([]uint8{0xc4, 0x34, 0x12})
+	cycles := gb.CALL_cc_nn([]uint8{0xc4, 0x34, 0x12})
+	assert.Equal(t, cycles, 24)
 	assert.Equal(t, gb.get16Reg(SP), uint16(0xfffd))
 	assert.Equal(t, gb.mainMemory.read(0xfffe), uint8(0x11))
 	assert.Equal(t, gb.mainMemory.read(0xfffd), uint8(0x25))
@@ -1046,7 +1189,8 @@ func TestCALL_cc_nn(t *testing.T) {
 	gb.set16Reg(PC, 0x1122)
 	gb.set16Reg(SP, 0xefff)
 	gb.modifyFlag(Z_FLAG, SET)
-	gb.CALL_cc_nn([]uint8{0xc4, 0x34, 0x12})
+	cycles = gb.CALL_cc_nn([]uint8{0xc4, 0x34, 0x12})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(SP), uint16(0xefff))
 	assert.Equal(t, gb.mainMemory.read(0xeffe), uint8(0x00))
 	assert.Equal(t, gb.mainMemory.read(0xeffd), uint8(0x00))
@@ -1056,7 +1200,8 @@ func TestCALL_cc_nn(t *testing.T) {
 	gb.set16Reg(PC, 0x1122)
 	gb.set16Reg(SP, 0xefff)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.CALL_cc_nn([]uint8{0xdc, 0x34, 0x12})
+	cycles = gb.CALL_cc_nn([]uint8{0xdc, 0x34, 0x12})
+	assert.Equal(t, cycles, 12)
 	assert.Equal(t, gb.get16Reg(SP), uint16(0xefff))
 	assert.Equal(t, gb.mainMemory.read(0xeffe), uint8(0x00))
 	assert.Equal(t, gb.mainMemory.read(0xeffd), uint8(0x00))
@@ -1065,7 +1210,8 @@ func TestCALL_cc_nn(t *testing.T) {
 	gb.set16Reg(PC, 0x1122)
 	gb.set16Reg(SP, 0xefff)
 	gb.modifyFlag(C_FLAG, SET)
-	gb.CALL_cc_nn([]uint8{0xdc, 0x34, 0x12})
+	cycles = gb.CALL_cc_nn([]uint8{0xdc, 0x34, 0x12})
+	assert.Equal(t, cycles, 24)
 	assert.Equal(t, gb.get16Reg(SP), uint16(0xeffd))
 	assert.Equal(t, gb.mainMemory.read(0xeffe), uint8(0x11))
 	assert.Equal(t, gb.mainMemory.read(0xeffd), uint8(0x25))
@@ -1077,7 +1223,8 @@ func TestRET(t *testing.T) {
 	gb.set16Reg(SP, 0xff85)
 	gb.mainMemory.write(0xff85, 0x34)
 	gb.mainMemory.write(0xff86, 0x12)
-	gb.RET([]uint8{0x39})
+	cycles := gb.RET([]uint8{0x39})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x1234))
 }
 
@@ -1087,7 +1234,8 @@ func TestRETI(t *testing.T) {
 	gb.set16Reg(SP, 0xff85)
 	gb.mainMemory.write(0xff85, 0x34)
 	gb.mainMemory.write(0xff86, 0x12)
-	gb.RETI([]uint8{0xd9})
+	cycles := gb.RETI([]uint8{0xd9})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x1234))
 	assert.Equal(t, gb.interruptEnabled, true)
 }
@@ -1098,7 +1246,8 @@ func TestRET_cc(t *testing.T) {
 	gb.set16Reg(SP, 0xff85)
 	gb.mainMemory.write(0xff85, 0x34)
 	gb.mainMemory.write(0xff86, 0x12)
-	gb.RET_cc([]uint8{0xc0})
+	cycles := gb.RET_cc([]uint8{0xc0})
+	assert.Equal(t, cycles, 20)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x1234))
 
 	gb.modifyFlag(Z_FLAG, SET)
@@ -1106,7 +1255,8 @@ func TestRET_cc(t *testing.T) {
 	gb.set16Reg(SP, 0xff85)
 	gb.mainMemory.write(0xff85, 0x34)
 	gb.mainMemory.write(0xff86, 0x12)
-	gb.RET_cc([]uint8{0xc0})
+	cycles = gb.RET_cc([]uint8{0xc0})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x0001))
 
 	gb.modifyFlag(C_FLAG, SET)
@@ -1114,7 +1264,8 @@ func TestRET_cc(t *testing.T) {
 	gb.set16Reg(SP, 0xff85)
 	gb.mainMemory.write(0xff85, 0x34)
 	gb.mainMemory.write(0xff86, 0x12)
-	gb.RET_cc([]uint8{0xd0})
+	cycles = gb.RET_cc([]uint8{0xd0})
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x0001))
 
 	gb.modifyFlag(C_FLAG, SET)
@@ -1122,7 +1273,8 @@ func TestRET_cc(t *testing.T) {
 	gb.set16Reg(SP, 0xff85)
 	gb.mainMemory.write(0xff85, 0x34)
 	gb.mainMemory.write(0xff86, 0x12)
-	gb.RET_cc([]uint8{0xd8})
+	cycles = gb.RET_cc([]uint8{0xd8})
+	assert.Equal(t, cycles, 20)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x1234))
 }
 
@@ -1130,7 +1282,8 @@ func TestRST(t *testing.T) {
 	gb := initGameboy()
 	gb.set16Reg(PC, 0x1122)
 	gb.set16Reg(SP, 0xffff)
-	gb.RST([]uint8{0xf7})
+	cycles := gb.RST([]uint8{0xf7})
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, gb.get16Reg(SP), uint16(0xfffd))
 	assert.Equal(t, gb.mainMemory.read(0xfffe), uint8(0x11))
 	assert.Equal(t, gb.mainMemory.read(0xfffd), uint8(0x23))
@@ -1142,24 +1295,28 @@ func TestDAA(t *testing.T) {
 	gb.set8Reg(A, 0x45)
 	gb.set8Reg(B, 0x38)
 	gb.ADD_a_r([]uint8{0x80})
-	gb.DAA([]uint8{0x27})
+	cycles := gb.DAA([]uint8{0x27})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x83))
 
 	gb.SUB_a_r([]uint8{0x90})
-	gb.DAA([]uint8{0x27})
+	cycles = gb.DAA([]uint8{0x27})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x45))
 }
 
 func TestCPL(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(A, 0xc3)
-	gb.CPL([]uint8{0x2f})
+	cycles := gb.CPL([]uint8{0x2f})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get8Reg(A), uint8(0x3c))
 }
 
 func TestNOP(t *testing.T) {
 	gb := initGameboy()
-	gb.NOP([]uint8{0x00})
+	cycles := gb.NOP([]uint8{0x00})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.get16Reg(PC), uint16(0x0001))
 }
 
@@ -1167,7 +1324,8 @@ func TestRL_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(B, 0x80)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.RL_r([]uint8{0x05}) // RL_r
+	cycles := gb.RL_r([]uint8{0x05}) // RL_r
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, uint8(0x00), gb.get8Reg(B))
 	assert.Equal(t, uint8(0x90), gb.get8Reg(F)) // C,Z FLAG set, H,N FLAG cleared
 }
@@ -1177,7 +1335,8 @@ func TestRL_hl(t *testing.T) {
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x11)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.RLC_hl([]uint8{0xbe}) // RL_hl
+	cycles := gb.RLC_hl([]uint8{0xbe}) // RL_hl
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, uint8(0x22), gb.mainMemory.read(0xff85))
 	assert.Equal(t, uint8(0x00), gb.get8Reg(F)) // Z, C,H,N FLAG cleared
 }
@@ -1186,7 +1345,8 @@ func TestRRC_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(B, 0x01)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.RRC_r([]uint8{0x05}) // RRC_r
+	cycles := gb.RRC_r([]uint8{0x05}) // RRC_r
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, uint8(0x80), gb.get8Reg(B))
 	assert.Equal(t, uint8(0x10), gb.get8Reg(F)) // C FLAG set, Z,H,N FLAG cleared
 }
@@ -1196,7 +1356,8 @@ func TestRRC_hl(t *testing.T) {
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x00)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.RRC_hl([]uint8{0xbe}) // RRC_hl
+	cycles := gb.RRC_hl([]uint8{0xbe}) // RRC_hl
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, uint8(0x00), gb.mainMemory.read(0xff85))
 	assert.Equal(t, uint8(0x80), gb.get8Reg(F)) // Z FLAG set, C,H,N FLAG cleared
 }
@@ -1205,7 +1366,8 @@ func TestRR_r(t *testing.T) {
 	gb := initGameboy()
 	gb.set8Reg(B, 0x01)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.RR_r([]uint8{0x05}) // RR_r
+	cycles := gb.RR_r([]uint8{0x05}) // RR_r
+	assert.Equal(t, cycles, 8)
 	assert.Equal(t, uint8(0x00), gb.get8Reg(B))
 	assert.Equal(t, uint8(0x90), gb.get8Reg(F)) // C,Z FLAG set, H,N FLAG cleared
 }
@@ -1215,32 +1377,37 @@ func TestRR_hl(t *testing.T) {
 	gb.set16Reg(HL, 0xff85)
 	gb.mainMemory.write(0xff85, 0x8a)
 	gb.modifyFlag(C_FLAG, CLEAR)
-	gb.RR_hl([]uint8{0xbe}) // RR_hl
+	cycles := gb.RR_hl([]uint8{0xbe}) // RR_hl
+	assert.Equal(t, cycles, 16)
 	assert.Equal(t, uint8(0x45), gb.mainMemory.read(0xff85))
 	assert.Equal(t, uint8(0x00), gb.get8Reg(F)) // Z, C,H,N FLAG cleared
 }
 
 func TestSCF(t *testing.T) {
 	gb := initGameboy()
-	gb.SCF([]uint8{0x37})
+	cycles := gb.SCF([]uint8{0x37})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.getFlag(C_FLAG), uint8(1))
 }
 
 func TestCCF(t *testing.T) {
 	gb := initGameboy()
 	gb.modifyFlag(C_FLAG, SET)
-	gb.CCF([]uint8{0x3f})
+	cycles := gb.CCF([]uint8{0x3f})
+	assert.Equal(t, cycles, 4)
 	assert.Equal(t, gb.getFlag(C_FLAG), uint8(0))
 }
 
 func TestDI(t *testing.T) {
 	gb := initGameboy()
-	gb.DI([]uint8{0xf3})
+	cycles := gb.DI([]uint8{0xf3})
+	assert.Equal(t, cycles, 4)
 	assert.True(t, !gb.interruptEnabled)
 }
 
 func TestEI(t *testing.T) {
 	gb := initGameboy()
-	gb.EI([]uint8{0xfb})
+	cycles := gb.EI([]uint8{0xfb})
+	assert.Equal(t, cycles, 4)
 	assert.True(t, gb.interruptEnabled)
 }


### PR DESCRIPTION
Used a combination of the following:
http://problemkaputt.de/pandocs.htm#cpuregistersandflags
http://marc.rawer.de/Gameboy/Docs/GBCPUman.pdf

Only discrepancy was bit n, [hl]: pandocs claim it is 12 cycles, all other sources say 16. Going with 16.