### PR TITLE
Added a separate thread to increment a TSC every 953 ns. CPU synchron…

### DIFF
--- a/goboy/emu.go
+++ b/goboy/emu.go
@@ -4,7 +4,7 @@ func (g *GameBoy) Step() {
 	/* 3 is the max length of an instruction (I think) */
 	pc := g.regs[PC]
 	opCode := g.mainMemory.read(pc)
-
+	var cycles int = 0
 	/* Switch on bits 6-7 */
 	switch opCode & 0xc0 {
 	case 0x00:
@@ -16,16 +16,16 @@ func (g *GameBoy) Step() {
 			case 0x00:
 				/* nop */
 				instruction := []uint8{opCode}
-				g.NOP(instruction)
+				cycles = g.NOP(instruction)
 			case 0x08:
-				g.LD_nn_sp(g.mainMemory.readN(pc, 3))
+				cycles = g.LD_nn_sp(g.mainMemory.readN(pc, 3))
 				/* LD [nn], sp */
 			case 0x10:
 				/*
 				 * STOP
 				 */
 			case 0x18:
-				g.JR_e(g.mainMemory.readN(pc, 2))
+				cycles = g.JR_e(g.mainMemory.readN(pc, 2))
 				/*
 				 * jr E - jump to PC + E
 				 */
@@ -39,17 +39,17 @@ func (g *GameBoy) Step() {
 				/* jr nc, nn */
 				fallthrough
 			case 0x38:
-				g.JR_cc_e(g.mainMemory.readN(pc, 2))
+				cycles = g.JR_cc_e(g.mainMemory.readN(pc, 2))
 				/* jr c, nn */
 			}
 		case 0x01:
 			/* switch on bit 3 */
 			switch opCode & 0x08 {
 			case 0x00:
-				g.LD_dd_nn(g.mainMemory.readN(pc, 3))
+				cycles = g.LD_dd_nn(g.mainMemory.readN(pc, 3))
 				/* ld r16, nn */
 			case 0x08:
-				g.ADD_hl_ss(g.mainMemory.readN(pc, 1))
+				cycles = g.ADD_hl_ss(g.mainMemory.readN(pc, 1))
 				/* add hl, r16 */
 			}
 		case 0x02:
@@ -59,32 +59,32 @@ func (g *GameBoy) Step() {
 				/* switch on bits 4-5 */
 				switch opCode & 0x30 {
 				case 0x00:
-					g.LD_bc_a(g.mainMemory.readN(pc, 1))
+					cycles = g.LD_bc_a(g.mainMemory.readN(pc, 1))
 					/* ld [bc], a */
 				case 0x10:
-					g.LD_de_a(g.mainMemory.readN(pc, 1))
+					cycles = g.LD_de_a(g.mainMemory.readN(pc, 1))
 					/* ld [de], a */
 				case 0x20:
-					g.LDI_hl_a(g.mainMemory.readN(pc, 1))
+					cycles = g.LDI_hl_a(g.mainMemory.readN(pc, 1))
 					/* LDI [HL], A */
 				case 0x30:
-					g.LDD_hl_a(g.mainMemory.readN(pc, 1))
+					cycles = g.LDD_hl_a(g.mainMemory.readN(pc, 1))
 					/* LDD [HL], A */
 				}
 			case 0x08:
 				/* switch on bits 4-5 */
 				switch opCode & 0x30 {
 				case 0x00:
-					g.LD_a_bc(g.mainMemory.readN(pc, 1))
+					cycles = g.LD_a_bc(g.mainMemory.readN(pc, 1))
 					/* ld a, [bc] */
 				case 0x10:
-					g.LD_a_de(g.mainMemory.readN(pc, 1))
+					cycles = g.LD_a_de(g.mainMemory.readN(pc, 1))
 					/* ld a, [de] */
 				case 0x20:
-					g.LDI_a_hl(g.mainMemory.readN(pc, 1))
+					cycles = g.LDI_a_hl(g.mainMemory.readN(pc, 1))
 					/* ldi A, [HL] */
 				case 0x30:
-					g.LDD_a_hl(g.mainMemory.readN(pc, 1))
+					cycles = g.LDD_a_hl(g.mainMemory.readN(pc, 1))
 					/* ldd A, [HL] */
 				}
 			}
@@ -92,47 +92,47 @@ func (g *GameBoy) Step() {
 			/* switch on bit 3 */
 			switch opCode & 0x08 {
 			case 0x00:
-				g.INC_ss(g.mainMemory.readN(pc, 1))
+				cycles = g.INC_ss(g.mainMemory.readN(pc, 1))
 				/* inc r16 */
 			case 0x08:
-				g.DEC_ss(g.mainMemory.readN(pc, 1))
+				cycles = g.DEC_ss(g.mainMemory.readN(pc, 1))
 				/* dec r16 */
 			}
 		case 0x04:
-			g.INC_r(g.mainMemory.readN(pc, 1))
+			cycles = g.INC_r(g.mainMemory.readN(pc, 1))
 			/* inc r8 */
 		case 0x05:
-			g.DEC_r(g.mainMemory.readN(pc, 1))
+			cycles = g.DEC_r(g.mainMemory.readN(pc, 1))
 			/* dec r8 */
 		case 0x06:
-			g.LD_r_n(g.mainMemory.readN(pc, 2))
+			cycles = g.LD_r_n(g.mainMemory.readN(pc, 2))
 			/* ld r8, n */
 		case 0x07:
 			/* switch on bits 3-5 */
 			switch opCode & 0x38 {
 			case 0x00:
-				g.RLCA(g.mainMemory.readN(pc, 1))
+				cycles = g.RLCA(g.mainMemory.readN(pc, 1))
 				/* RLCA */
 			case 0x08:
-				g.RRCA(g.mainMemory.readN(pc, 1))
+				cycles = g.RRCA(g.mainMemory.readN(pc, 1))
 				/* RRCA */
 			case 0x10:
-				g.RLA(g.mainMemory.readN(pc, 1))
+				cycles = g.RLA(g.mainMemory.readN(pc, 1))
 				/* RLA */
 			case 0x18:
-				g.RRA(g.mainMemory.readN(pc, 1))
+				cycles = g.RRA(g.mainMemory.readN(pc, 1))
 				/* RRA */
 			case 0x20:
-				g.DAA(g.mainMemory.readN(pc, 1))
+				cycles = g.DAA(g.mainMemory.readN(pc, 1))
 				/* DAA */
 			case 0x28:
-				g.CPL(g.mainMemory.readN(pc, 1))
+				cycles = g.CPL(g.mainMemory.readN(pc, 1))
 				/* CPL */
 			case 0x30:
-				g.SCF(g.mainMemory.readN(pc, 1))
+				cycles = g.SCF(g.mainMemory.readN(pc, 1))
 				/* SCF */
 			case 0x38:
-				g.CCF(g.mainMemory.readN(pc, 1))
+				cycles = g.CCF(g.mainMemory.readN(pc, 1))
 				/* CCF */
 			}
 		}
@@ -143,16 +143,16 @@ func (g *GameBoy) Step() {
 			case 0x30:
 				/* halt */
 			default:
-				g.LD_r_hl(g.mainMemory.readN(pc, 1))
+				cycles = g.LD_r_hl(g.mainMemory.readN(pc, 1))
 				/* ld r8, [hl] */
 			}
 		default:
 			switch opCode & 0x38 {
 			case 0x30:
-				g.LD_hl_r(g.mainMemory.readN(pc, 1))
+				cycles = g.LD_hl_r(g.mainMemory.readN(pc, 1))
 				/* ld [hl], r8 */
 			default:
-				g.LD_r_r(g.mainMemory.readN(pc, 1))
+				cycles = g.LD_r_r(g.mainMemory.readN(pc, 1))
 				/* ld r8, r8 */
 			}
 		}
@@ -163,67 +163,67 @@ func (g *GameBoy) Step() {
 			// most ADD instructions
 			switch opCode & 0x07 {
 			case 0x06:
-				g.ADD_a_hl(g.mainMemory.readN(pc, 1))
+				cycles = g.ADD_a_hl(g.mainMemory.readN(pc, 1))
 				// add A, [HL]
 			default:
 				// add A, r
-				g.ADD_a_r(g.mainMemory.readN(pc, 1))
+				cycles = g.ADD_a_r(g.mainMemory.readN(pc, 1))
 			}
 		case 0x08:
 			// most ADC instructions
 			switch opCode & 0x07 {
 			case 0x06:
 				// adc A, [HL]
-				g.ADC_a_hl(g.mainMemory.readN(pc, 1))
+				cycles = g.ADC_a_hl(g.mainMemory.readN(pc, 1))
 			default:
-				g.ADC_a_r(g.mainMemory.readN(pc, 1))
+				cycles = g.ADC_a_r(g.mainMemory.readN(pc, 1))
 			}
 		case 0x10:
 			// SUB instructions
 			switch opCode & 0x07 {
 			case 0x06:
-				g.SUB_a_hl(g.mainMemory.readN(pc, 1))
+				cycles = g.SUB_a_hl(g.mainMemory.readN(pc, 1))
 			default:
-				g.SUB_a_r(g.mainMemory.readN(pc, 1))
+				cycles = g.SUB_a_r(g.mainMemory.readN(pc, 1))
 			}
 		case 0x18:
 			// SBC instructions
 			switch opCode & 0x07 {
 			case 0x06:
-				g.SBC_a_hl(g.mainMemory.readN(pc, 1))
+				cycles = g.SBC_a_hl(g.mainMemory.readN(pc, 1))
 			default:
-				g.SUB_a_r(g.mainMemory.readN(pc, 1))
+				cycles = g.SUB_a_r(g.mainMemory.readN(pc, 1))
 			}
 		case 0x20:
 			// AND instructions
 			switch opCode & 0x07 {
 			case 0x06:
-				g.AND_a_hl(g.mainMemory.readN(pc, 1))
+				cycles = g.AND_a_hl(g.mainMemory.readN(pc, 1))
 			default:
-				g.AND_a_r(g.mainMemory.readN(pc, 1))
+				cycles = g.AND_a_r(g.mainMemory.readN(pc, 1))
 			}
 		case 0x28:
 			// XOR instructions
 			switch opCode & 0x07 {
 			case 0x06:
-				g.XOR_a_hl(g.mainMemory.readN(pc, 1))
+				cycles = g.XOR_a_hl(g.mainMemory.readN(pc, 1))
 			default:
-				g.XOR_a_r(g.mainMemory.readN(pc, 1))
+				cycles = g.XOR_a_r(g.mainMemory.readN(pc, 1))
 			}
 		case 0x30:
 			// OR instructions
 			switch opCode & 0x07 {
 			case 0x06:
-				g.OR_a_hl(g.mainMemory.readN(pc, 1))
+				cycles = g.OR_a_hl(g.mainMemory.readN(pc, 1))
 			default:
-				g.OR_a_r(g.mainMemory.readN(pc, 1))
+				cycles = g.OR_a_r(g.mainMemory.readN(pc, 1))
 			}
 		case 0x38:
 			switch opCode & 0x07 {
 			case 0x06:
-				g.CP_a_hl(g.mainMemory.readN(pc, 1))
+				cycles = g.CP_a_hl(g.mainMemory.readN(pc, 1))
 			default:
-				g.CP_a_r(g.mainMemory.readN(pc, 1))
+				cycles = g.CP_a_r(g.mainMemory.readN(pc, 1))
 			}
 		}
 	case 0xc0:
@@ -237,39 +237,39 @@ func (g *GameBoy) Step() {
 			case 0x10:
 				fallthrough
 			case 0x18:
-				g.RET_cc(g.mainMemory.readN(pc, 1))
+				cycles = g.RET_cc(g.mainMemory.readN(pc, 1))
 				/* ret CC - conditional return */
 			case 0x20:
-				g.LD_n_a(g.mainMemory.readN(pc, 2))
+				cycles = g.LD_n_a(g.mainMemory.readN(pc, 2))
 				/* ld [0xff00 + n], A */
 			case 0x28:
-				g.ADD_sp_e(g.mainMemory.readN(pc, 2))
+				cycles = g.ADD_sp_e(g.mainMemory.readN(pc, 2))
 				/* add SP, n */
 			case 0x30:
-				g.LD_a_n(g.mainMemory.readN(pc, 2))
+				cycles = g.LD_a_n(g.mainMemory.readN(pc, 2))
 				/* ld A, [0xff00 + n] */
 			case 0x38:
-				g.LDHL_sp_e(g.mainMemory.readN(pc, 2))
+				cycles = g.LDHL_sp_e(g.mainMemory.readN(pc, 2))
 				/* ldhl SP, n */
 			}
 		case 0x01:
 			switch opCode & 0x08 {
 			case 0x00:
-				g.POP_qq(g.mainMemory.readN(pc, 1))
+				cycles = g.POP_qq(g.mainMemory.readN(pc, 1))
 				/* pop r16 */
 			case 0x08:
 				switch opCode & 0x30 {
 				case 0x00:
-					g.RET(g.mainMemory.readN(pc, 1))
+					cycles = g.RET(g.mainMemory.readN(pc, 1))
 					/* ret */
 				case 0x10:
-					g.RETI(g.mainMemory.readN(pc, 1))
+					cycles = g.RETI(g.mainMemory.readN(pc, 1))
 					/* reti */
 				case 0x20:
-					g.JP_hl(g.mainMemory.readN(pc, 1))
+					cycles = g.JP_hl(g.mainMemory.readN(pc, 1))
 					/* jp hl */
 				case 0x30:
-					g.LD_sp_hl(g.mainMemory.readN(pc, 1))
+					cycles = g.LD_sp_hl(g.mainMemory.readN(pc, 1))
 					/* ld sp, hl */
 				}
 			}
@@ -283,25 +283,25 @@ func (g *GameBoy) Step() {
 			case 0x10:
 				fallthrough
 			case 0x18:
-				g.JP_cc_nn(g.mainMemory.readN(pc, 3))
+				cycles = g.JP_cc_nn(g.mainMemory.readN(pc, 3))
 				/* JP cc (conditional jump) */
 			case 0x20:
-				g.LD_c_a(g.mainMemory.readN(pc, 1))
+				cycles = g.LD_c_a(g.mainMemory.readN(pc, 1))
 				/* LD [0xff00 + C], A */
 			case 0x28:
-				g.LD_nn_a(g.mainMemory.readN(pc, 3))
+				cycles = g.LD_nn_a(g.mainMemory.readN(pc, 3))
 				/* LD [nn], A */
 			case 0x30:
-				g.LD_a_c(g.mainMemory.readN(pc, 1))
+				cycles = g.LD_a_c(g.mainMemory.readN(pc, 1))
 				/* LD A, [0xff00 + C] */
 			case 0x38:
-				g.LD_a_nn(g.mainMemory.readN(pc, 3))
+				cycles = g.LD_a_nn(g.mainMemory.readN(pc, 3))
 				/* LD A, [nn] */
 			}
 		case 0x03:
 			switch opCode & 0x38 {
 			case 0x00:
-				g.JP_nn(g.mainMemory.readN(pc, 3))
+				cycles = g.JP_nn(g.mainMemory.readN(pc, 3))
 				/* jp nn */
 			case 0x08:
 				/* 0xcb prefix */
@@ -313,83 +313,83 @@ func (g *GameBoy) Step() {
 					case 0x00:
 						switch opCode & 0x07 {
 						case 0x06:
-							g.RLC_hl(g.mainMemory.readN(pc, 2))
+							cycles = g.RLC_hl(g.mainMemory.readN(pc, 2))
 						default:
-							g.RLC_r(g.mainMemory.readN(pc, 2))
+							cycles = g.RLC_r(g.mainMemory.readN(pc, 2))
 						}
 					case 0x08:
 						switch opCode & 0x07 {
 						case 0x06:
-							g.RRC_hl(g.mainMemory.readN(pc, 2))
+							cycles = g.RRC_hl(g.mainMemory.readN(pc, 2))
 						default:
-							g.RRC_r(g.mainMemory.readN(pc, 2))
+							cycles = g.RRC_r(g.mainMemory.readN(pc, 2))
 						}
 					case 0x10:
 						switch opCode & 0x07 {
 						case 0x06:
-							g.RL_hl(g.mainMemory.readN(pc, 2))
+							cycles = g.RL_hl(g.mainMemory.readN(pc, 2))
 						default:
-							g.RL_r(g.mainMemory.readN(pc, 2))
+							cycles = g.RL_r(g.mainMemory.readN(pc, 2))
 						}
 					case 0x18:
 						switch opCode & 0x07 {
 						case 0x06:
-							g.RR_hl(g.mainMemory.readN(pc, 2))
+							cycles = g.RR_hl(g.mainMemory.readN(pc, 2))
 						default:
-							g.RR_r(g.mainMemory.readN(pc, 2))
+							cycles = g.RR_r(g.mainMemory.readN(pc, 2))
 						}
 					case 0x20:
 						switch opCode & 0x07 {
 						case 0x06:
-							g.SLA_hl(g.mainMemory.readN(pc, 2))
+							cycles = g.SLA_hl(g.mainMemory.readN(pc, 2))
 						default:
-							g.SLA_r(g.mainMemory.readN(pc, 2))
+							cycles = g.SLA_r(g.mainMemory.readN(pc, 2))
 						}
 					case 0x28:
 						switch opCode & 0x07 {
 						case 0x06:
-							g.SRA_hl(g.mainMemory.readN(pc, 2))
+							cycles = g.SRA_hl(g.mainMemory.readN(pc, 2))
 						default:
-							g.SRA_r(g.mainMemory.readN(pc, 2))
+							cycles = g.SRA_r(g.mainMemory.readN(pc, 2))
 						}
 					case 0x30:
 						switch opCode & 0x07 {
 						case 0x06:
-							g.SWAP_hl(g.mainMemory.readN(pc, 2))
+							cycles = g.SWAP_hl(g.mainMemory.readN(pc, 2))
 						default:
-							g.SWAP_r(g.mainMemory.readN(pc, 2))
+							cycles = g.SWAP_r(g.mainMemory.readN(pc, 2))
 						}
 					case 0x38:
 						switch opCode & 0x07 {
 						case 0x06:
-							g.SRL_hl(g.mainMemory.readN(pc, 2))
+							cycles = g.SRL_hl(g.mainMemory.readN(pc, 2))
 						default:
-							g.SRL_r(g.mainMemory.readN(pc, 2))
+							cycles = g.SRL_r(g.mainMemory.readN(pc, 2))
 						}
 					}
 				case 0x40:
 					/* bit b, r8 */
 					switch opCode & 0x07 {
 					case 0x06:
-						g.BIT_b_hl(g.mainMemory.readN(pc, 2))
+						cycles = g.BIT_b_hl(g.mainMemory.readN(pc, 2))
 					default:
-						g.BIT_b_r(g.mainMemory.readN(pc, 2))
+						cycles = g.BIT_b_r(g.mainMemory.readN(pc, 2))
 					}
 				case 0x80:
 					/* res b, r8 */
 					switch opCode & 0x07 {
 					case 0x06:
-						g.RES_b_hl(g.mainMemory.readN(pc, 2))
+						cycles = g.RES_b_hl(g.mainMemory.readN(pc, 2))
 					default:
-						g.RES_b_r(g.mainMemory.readN(pc, 2))
+						cycles = g.RES_b_r(g.mainMemory.readN(pc, 2))
 					}
 				case 0xc0:
 					/* set b, r8 */
 					switch opCode & 0x07 {
 					case 0x06:
-						g.SET_b_hl(g.mainMemory.readN(pc, 2))
+						cycles = g.SET_b_hl(g.mainMemory.readN(pc, 2))
 					default:
-						g.SET_b_r(g.mainMemory.readN(pc, 2))
+						cycles = g.SET_b_r(g.mainMemory.readN(pc, 2))
 					}
 				}
 			case 0x10:
@@ -401,10 +401,10 @@ func (g *GameBoy) Step() {
 			case 0x28:
 				/* Illegal */
 			case 0x30:
-				g.DI(g.mainMemory.readN(pc, 1))
+				cycles = g.DI(g.mainMemory.readN(pc, 1))
 				/* di */
 			case 0x38:
-				g.EI(g.mainMemory.readN(pc, 1))
+				cycles = g.EI(g.mainMemory.readN(pc, 1))
 				/* ei */
 			}
 		case 0x04:
@@ -417,7 +417,7 @@ func (g *GameBoy) Step() {
 			case 0x10:
 				fallthrough
 			case 0x18:
-				g.CALL_cc_nn(g.mainMemory.readN(pc, 3))
+				cycles = g.CALL_cc_nn(g.mainMemory.readN(pc, 3))
 				/* Call cc - conditional call */
 			default:
 				/* Illegal */
@@ -425,12 +425,12 @@ func (g *GameBoy) Step() {
 		case 0x05:
 			switch opCode & 0x08 {
 			case 0x00:
-				g.PUSH_qq(g.mainMemory.readN(pc, 1))
+				cycles = g.PUSH_qq(g.mainMemory.readN(pc, 1))
 				/* push r16 */
 			case 0x08:
 				switch opCode & 0x30 {
 				case 0x00:
-					g.CALL_nn(g.mainMemory.readN(pc, 3))
+					cycles = g.CALL_nn(g.mainMemory.readN(pc, 3))
 					/* call nn */
 				case 0x10:
 					/* Illegal */
@@ -443,26 +443,37 @@ func (g *GameBoy) Step() {
 		case 0x06:
 			switch opCode & 0x38 {
 			case 0x00:
-				g.ADD_a_n(g.mainMemory.readN(pc, 2))
+				cycles = g.ADD_a_n(g.mainMemory.readN(pc, 2))
 			case 0x08:
-				g.ADC_a_n(g.mainMemory.readN(pc, 2))
+				cycles = g.ADC_a_n(g.mainMemory.readN(pc, 2))
 			case 0x10:
-				g.SUB_a_n(g.mainMemory.readN(pc, 2))
+				cycles = g.SUB_a_n(g.mainMemory.readN(pc, 2))
 			case 0x18:
-				g.SBC_a_n(g.mainMemory.readN(pc, 2))
+				cycles = g.SBC_a_n(g.mainMemory.readN(pc, 2))
 			case 0x20:
-				g.AND_a_n(g.mainMemory.readN(pc, 2))
+				cycles = g.AND_a_n(g.mainMemory.readN(pc, 2))
 			case 0x28:
-				g.XOR_a_n(g.mainMemory.readN(pc, 2))
+				cycles = g.XOR_a_n(g.mainMemory.readN(pc, 2))
 			case 0x30:
-				g.OR_a_n(g.mainMemory.readN(pc, 2))
+				cycles = g.OR_a_n(g.mainMemory.readN(pc, 2))
 			case 0x38:
-				g.CP_a_n(g.mainMemory.readN(pc, 2))
+				cycles = g.CP_a_n(g.mainMemory.readN(pc, 2))
 			}
 		case 0x07:
-			g.RST(g.mainMemory.readN(pc, 1))
+			cycles = g.RST(g.mainMemory.readN(pc, 1))
 			/* rst p */
 		}
+	}
+
+	g.TSCStart += uint64(cycles)
+
+	/*
+	 * This loop could occur at the top of the function as well
+	 * Do not start executing instruction until TSCStart + cycles
+	 * We need to check g.Paused in case the Debugger is paused
+	 * with SIGINT, otherwise this may infinitely loop.
+	 */
+	for g.TSC < g.TSCStart && !g.Paused {
 	}
 }
 
@@ -509,11 +520,37 @@ func (g *GameBoy) interruptJumpHelper(target uint16) {
 	g.regs[PC] = target
 }
 
-func (Gb *GameBoy) GPULoop() {
-	for _ = range Gb.gpuClock.C {
+/* TODO: investigate good ways to test these Ticker loops */
+func (Gb *GameBoy) LCDLoop() {
+	for _ = range Gb.LCDClock.C {
 		// NOTE: Check debugger pause flag here
-		LY := Gb.mainMemory.ioregs[0x44]
-		LY = (LY + 1) % 0x9a // LY increments from 0 (0x00) to 153 (0x99) and then repeats
-		Gb.mainMemory.ioregs[0x44] = LY
+		if !Gb.Paused {
+			/* LY - 0xff44 */
+			LY := Gb.mainMemory.ioregs[0x44]
+			LY = (LY + 1) % 0x9a // LY increments from 0 (0x00) to 153 (0x99) and then repeats
+			Gb.mainMemory.ioregs[0x44] = LY
+			/*
+			 * LYC  - 0xff45
+			 * STAT - 0xff41
+			 * LYC and LC are continuously compared with each other. When
+			 * both values are identical, the coincident bit in the STAT register becomes
+			 * set, and (if enabled) a STAT interrupt is requested.
+			 */
+			LYC := Gb.mainMemory.ioregs[0x45]
+			if LYC == LY {
+				/* Set bit 6 in STAT */
+				STAT := Gb.mainMemory.ioregs[0x41]
+				STAT |= 0x40
+			}
+
+		}
+	}
+}
+
+func (Gb *GameBoy) TSCLoop() {
+	for _ = range Gb.CPUClock.C {
+		if !Gb.Paused {
+			Gb.TSC += 4
+		}
 	}
 }

--- a/goboy/goboy.go
+++ b/goboy/goboy.go
@@ -6,13 +6,25 @@ import "time"
 //  Frances was here!
 //      Where is Frances?
 
+const (
+	/*
+	 * 4.194304 MHz. Different for SGB, GBC
+	 * 1 / 4194304Hz * 1000 * 1000 * 1000ns = 238.418ns per clock, 953.674ns per machine clock
+	 */
+	GBClockPeriod = 953
+)
+
 type GameBoy struct {
 	rom              *GBROM // the ROM object
 	mainMemory       *GBMem // GB main memory
 	*Register               // register state
 	interruptEnabled bool
 	image            *image.RGBA // image to be displayed
-	gpuClock         *time.Ticker
+	LCDClock         *time.Ticker
+	CPUClock         *time.Ticker
+	TSC              uint64 /* like TSC on x86 */
+	TSCStart         uint64 /* starting TSC of next instruction */
+	Paused           bool
 }
 
 type Reg8ID int

--- a/goboy/main.go
+++ b/goboy/main.go
@@ -27,7 +27,11 @@ func main() {
 		mainMemory:       &GBMem{cartridge: &GBROM{}},
 		interruptEnabled: true,
 		image:            image.NewRGBA(image.Rect(0, 0, screenWidth, screenHeight)),
-		gpuClock:         time.NewTicker(108 * time.Microsecond),
+		LCDClock:         time.NewTicker(108 * time.Microsecond),
+		CPUClock:         time.NewTicker(GBClockPeriod),
+		TSC:              0,
+		TSCStart:         0,
+		Paused:           true,
 	}
 
 	// load rom from file
@@ -46,9 +50,11 @@ func main() {
 
 	d := NewDebugger(Gb)
 	/* Initialize SIGINT handler */
-	debuggersSignal = append(debuggersSignal, d)
-	go sigint_handler()
+	go d.SIGINTHandler()
 	signal.Notify(sig_chan, syscall.SIGINT)
+
+	go Gb.LCDLoop()
+	go Gb.TSCLoop()
 
 	debugLoop(d)
 }


### PR DESCRIPTION
…ized with the TSC

The first 4 instructions executed in the Tetris ROM are as follows:
```
0x0100: 00           nop
0x0101: c35001       jp     0x0150
0x0150: c38b02       jp     0x028b
0x028b: af           xor    a
```
which total 4 + 16 + 16 + 4 cycles.

```
>>> x/8i 0x0100
0x0100: 00           nop
0x0101: c35001       jp     0x0150
0x0104: ceed         adc    a, 0xed
0x0106: 66           ld     h, [hl]
0x0107: 66           ld     h, [hl]
0x0108: cc0d00       call   Z, 0x000d
0x010b: 0b           dec    bc
0x010c: 03           inc    bc
>>> x/8i 0x0150
0x0150: c38b02       jp     0x028b
0x0153: cd2b2a       call   0x2a2b
0x0156: f041         ld     a, [0xff00 + 0x41]
0x0158: e603         and    0x03
0x015a: 20fa         jr     NZ, -6
0x015c: 46           ld     b, [hl]
0x015d: f041         ld     a, [0xff00 + 0x41]
0x015f: e603         and    0x03
>>> x/8i 0x028b
0x028b: af           xor    a
0x028c: 21ffdf       ld     hl, 0xdfff
0x028f: 0e10         ld     c, 0x10
0x0291: 0600         ld     b, 0x00
0x0293: 32           ldd    [hl], a
0x0294: 05           dec    b
0x0295: 20fc         jr     NZ, -4
0x0297: 0d           dec    c
>>> b 0x28c
>>> p tsc
0
>>> c
>>> p tsc
40
>>>
```